### PR TITLE
Feat: Update iOS build to target iPhone SE (3rd gen) with iOS 15

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -20,13 +20,19 @@ jobs:
       with:
         xcode-version: 'latest-stable' # You can specify a version like '14.3.1'
 
+    - name: List available iOS simulators
+      run: xcrun simctl list devices
+
     - name: Build for Simulator
       run: |
         xcodebuild build \
           -project businesscard.xcodeproj \
           -scheme businesscard \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+          -destination 'platform=iOS Simulator,name=iPhone SE (3rd generation),OS=15.0' \
+          ONLY_ACTIVE_ARCH=YES \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGN_IDENTITY="" \
           CLEAN_BUILD=YES
 
     # Optional: Upload .app bundle as an artifact


### PR DESCRIPTION
- Modifies the GitHub Actions workflow to build for iPhone SE (3rd generation) using iOS 15.0.
- Ensures all necessary build parameters for CI are included.
- Retains the step to list available simulators for debugging purposes.
- Retains the step to upload the .app bundle as a build artifact.